### PR TITLE
Support `allowDiskUse`, `exec` and `mongoose.Types`

### DIFF
--- a/index.js
+++ b/index.js
@@ -58,10 +58,12 @@ var Schema = function () {
   };
 
   Model.aggregate = sinon.stub();
+  Model.allowDiskUse = sinon.stub();
   Model.count = sinon.stub();
   Model.create = sinon.stub();
   Model.distinct = sinon.stub();
   Model.ensureIndexes = sinon.stub();
+  Model.exec = sinon.stub();
   Model.find = sinon.stub();
   Model.findById = sinon.stub();
   Model.findByIdAndRemove = sinon.stub();
@@ -106,6 +108,7 @@ function createModelFromSchema(name, Type) {
 
 mongoose.Schema = Schema;
 mongoose.Schema.Types = { ObjectId: ''};  // Defining mongoose types as dummies.
+mongoose.Types = mongoose.Schema.Types;
 mongoose.model = createModelFromSchema;
 mongoose.connect = sinon.stub;
 

--- a/test/unit/index.js
+++ b/test/unit/index.js
@@ -21,6 +21,7 @@ describe('mongoose-mocks', function () {
     describe('mongoose Types', function() {
       it('should have an ObjectId type', function() {
         expect(Schema.Types).to.have.a.property('ObjectId');
+        expect(mongoose.Types).to.have.a.property('ObjectId');
       });
     });
     describe('mongoose Model functions', function () {
@@ -31,6 +32,9 @@ describe('mongoose-mocks', function () {
       });
 
       it('adds a stub for aggregate()', function () {
+        expect(Model.aggregate).to.be.a('function');
+      });
+      it('adds a stub for allowDiskUse()', function () {
         expect(Model.aggregate).to.be.a('function');
       });
       it('adds a stub for count()', function () {
@@ -44,6 +48,9 @@ describe('mongoose-mocks', function () {
       });
       it('adds a stub for ensureIndexes()', function () {
         expect(Model.ensureIndexes).to.be.a('function');
+      });
+      it('adds a stub for exec()', function () {
+        expect(Model.exec).to.be.a('function');
       });
       it('adds a stub for find()', function () {
         expect(Model.find).to.be.a('function');


### PR DESCRIPTION
This pull request addresses issues #9 and #10 so that `allowDiskUse`, `exec` and `mongoose.Types` are supported.
